### PR TITLE
Make RedHatAI the actual launcher default (both launchers still shipped ModelOpt)

### DIFF
--- a/launch-glm53-vllm-tp2-dflash2.sh
+++ b/launch-glm53-vllm-tp2-dflash2.sh
@@ -23,8 +23,28 @@ NODE_RANK="${1:?usage: launch-glm53-vllm-tp2.sh <0|1>}"
 
 IMAGE="ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2"
 NAME="vllm_glm53"
-MODEL_HOST_PATH="/var/tmp/glm-5.3-flash-nvfp4"
+# Checkpoint. The README's documented default is RedHatAI/GLM-5.3-Flash-NVFP4
+# (compressed-tensors) because the ModelOpt builds emit intermittent corrupted token IDs
+# -- vLLM #54150, measured 4/9/8 U+FFFD on a Hangul probe vs 0/0/0 for RedHatAI. The
+# launchers previously hardcoded the ModelOpt path, so the shipped default did not match
+# the documented one. Override with MODEL_HOST_PATH=... for the legacy/abliterated builds.
+MODEL_HOST_PATH="${MODEL_HOST_PATH:-/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat}"
 MODEL_PATH="/models/glm-5.3-flash-nvfp4"
+
+# Guard: fail loudly if the resolved checkpoint is a ModelOpt build, unless the operator
+# opted in. This is the mismatch that shipped for weeks -- the corruption is nearly
+# invisible in English prose and only bites inside tool-call blocks, so it will not
+# announce itself at boot.
+if [ -f "$MODEL_HOST_PATH/config.json" ] && [ "${ALLOW_MODELOPT:-0}" != "1" ]; then
+  _q=$(python3 -c "import json;print(json.load(open('$MODEL_HOST_PATH/config.json')).get('quantization_config',{}).get('quant_method',''))" 2>/dev/null || echo "")
+  if [ "$_q" = "modelopt" ]; then
+    echo "REFUSING: $MODEL_HOST_PATH is a ModelOpt build (quant_method=modelopt)." >&2
+    echo "  ModelOpt NVFP4 emits intermittent corrupted token IDs (vLLM #54150)." >&2
+    echo "  Use RedHatAI/GLM-5.3-Flash-NVFP4, or set ALLOW_MODELOPT=1 to override." >&2
+    exit 5
+  fi
+fi
+
 CACHE_HOST_PATH="/var/tmp/glm53-vllm-cache"
 HEAD_IP="192.168.192.2"
 MPORT="29521"

--- a/launch-glm53-vllm-tp2.sh
+++ b/launch-glm53-vllm-tp2.sh
@@ -10,8 +10,28 @@ NODE_RANK="${1:?usage: launch-glm53-vllm-tp2.sh <0|1>}"
 
 IMAGE="ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v8"
 NAME="vllm_glm53"
-MODEL_HOST_PATH="/var/tmp/glm-5.3-flash-nvfp4"
+# Checkpoint. The README's documented default is RedHatAI/GLM-5.3-Flash-NVFP4
+# (compressed-tensors) because the ModelOpt builds emit intermittent corrupted token IDs
+# -- vLLM #54150, measured 4/9/8 U+FFFD on a Hangul probe vs 0/0/0 for RedHatAI. The
+# launchers previously hardcoded the ModelOpt path, so the shipped default did not match
+# the documented one. Override with MODEL_HOST_PATH=... for the legacy/abliterated builds.
+MODEL_HOST_PATH="${MODEL_HOST_PATH:-/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat}"
 MODEL_PATH="/models/glm-5.3-flash-nvfp4"
+
+# Guard: fail loudly if the resolved checkpoint is a ModelOpt build, unless the operator
+# opted in. This is the mismatch that shipped for weeks -- the corruption is nearly
+# invisible in English prose and only bites inside tool-call blocks, so it will not
+# announce itself at boot.
+if [ -f "$MODEL_HOST_PATH/config.json" ] && [ "${ALLOW_MODELOPT:-0}" != "1" ]; then
+  _q=$(python3 -c "import json;print(json.load(open('$MODEL_HOST_PATH/config.json')).get('quantization_config',{}).get('quant_method',''))" 2>/dev/null || echo "")
+  if [ "$_q" = "modelopt" ]; then
+    echo "REFUSING: $MODEL_HOST_PATH is a ModelOpt build (quant_method=modelopt)." >&2
+    echo "  ModelOpt NVFP4 emits intermittent corrupted token IDs (vLLM #54150)." >&2
+    echo "  Use RedHatAI/GLM-5.3-Flash-NVFP4, or set ALLOW_MODELOPT=1 to override." >&2
+    exit 5
+  fi
+fi
+
 CACHE_HOST_PATH="/var/tmp/glm53-vllm-cache"
 HEAD_IP="192.168.192.2"
 MPORT="29521"


### PR DESCRIPTION
The README has said **"Default checkpoint: `RedHatAI/GLM-5.3-Flash-NVFP4`"** since the corruption fix landed. Both launchers still hardcoded:

```
MODEL_HOST_PATH="/var/tmp/glm-5.3-flash-nvfp4"
```

which on a real deployment holds the **ModelOpt** build — verified on our fleet: `quant_method=modelopt`, 120 shards, versus the RedHatAI build's `compressed-tensors` / 11 shards sitting right next to it.

So anyone following this recipe got the corruption-prone checkpoint while reading that they were on the corruption-free one. I only caught it because I benchmarked TP2 and noticed the shard count didn't match the README's "11 large shards vs 120 small" line — my own first TP2 numbers were measured on the wrong checkpoint and discarded.

**Why it survived:** ModelOpt corruption is nearly invisible in English prose (4/9/8 U+FFFD on the Hangul probe vs 0/0/0) and only really bites inside a tool-call block where the parser desyncs. It does not announce itself at boot.

**Changes**
- both launchers default to `/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat`, still overridable via `MODEL_HOST_PATH` for legacy/abliterated builds
- a preflight guard that **refuses to launch a modelopt checkpoint** (exit 5) unless `ALLOW_MODELOPT=1`

The guard is the part I'd argue for keeping. This is the third instance today of documented-one-way / shipped-another (TP4's README vs its launcher, DS4's `NCCL_IB_MERGE_NICS` never reaching the container), and the only one of the three that a machine can check. Verified on a node: exits 5 on the ModelOpt path, before `docker rm` or `docker run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)