### PR TITLE
TP2: adopt KV 6 GiB from #12, add bench_robust.py, document the k crossover

### DIFF
--- a/docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md
+++ b/docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md
@@ -1,0 +1,78 @@
+# TP2 tuning: KV pool, speculative depth, and CUDA graphs
+
+Measured 2026-09-02 on a 2x DGX Spark (GB10) pair, RedHatAI compressed-tensors checkpoint,
+DFlash2, temperature 0, 8-prompt set, median of 3, **each arm under its own
+`VLLM_CACHE_ROOT`** (vLLM [#53366](https://github.com/vllm-project/vllm/issues/53366) omits
+`num_speculative_tokens` from the config hash, so a shared cache can serve one arm an
+artifact compiled for a different k).
+
+Findings originate in [#12](https://github.com/tonyd2wild/GLM-5.3-Flash-NVFP4-DFlash2-2x-DGX-Spark/pull/12)
+by @tmooch; this doc records the reproduction on the reference fleet.
+
+## KV 3 -> 6 GiB: unconditional
+
+@tmooch measured 6 preemptions under load at 3 GiB and 0 at 6 GiB, with the pool going
+310,292 -> 678,661 tokens. Preemption under load costs more than any tok/s figure, and the
+memory is available. **Adopted as the default.**
+
+## Speculative depth: k=7 below C4, k=5 above it
+
+`num_speculative_tokens` is a **workload choice, not a default.** It inverts at C4:
+
+| C | k=7 | k=5 | delta |
+|---|---|---|---|
+| 1 | 44.75 | 42.18 | −5.7% |
+| 2 | 68.18 | 64.12 | −6.0% |
+| **4** | 64.83 | **84.20** | **+29.9%** |
+| **6** | 84.82 | **100.33** | **+18.3%** |
+
+Single stream goes the other way — k=5 is slower on every prompt:
+
+| prompt | k=7 | k=5 | delta |
+|---|---|---|---|
+| count-to-100 | 67.12 | 55.50 | −17.3% |
+| code | 47.33 | 43.15 | −8.8% |
+| tooluse | 48.72 | 44.94 | −7.8% |
+| sql | 41.19 | 38.12 | −7.5% |
+| json | 46.73 | 43.83 | −6.2% |
+| math | 41.26 | 39.80 | −3.5% |
+
+**Mechanism.** At low concurrency the engine is weight-read-bound, so the extra draft
+positions are nearly free and more k means more accepted tokens per step. Under load,
+verify compute binds — and on a 288-expert MoE it grows super-linearly in k, because each
+extra verified token activates more experts — so fewer, higher-quality draft positions win.
+
+**The default stays k=7** (single-user and low-concurrency is the common case, and it is
+what the README's headline figures use). Serving deep concurrency should set k=5, or better,
+use a schedule with the crossover at C4:
+
+```json
+"num_speculative_tokens_per_batch_size": [[1,3,7],[4,512,5]]
+```
+
+### Do not tune toward acceptance ratio
+
+Under k=5 the acceptance **ratio rose on every prompt** (count-to-100 0.940 -> 0.977,
+code 0.664 -> 0.748, tooluse 0.736 -> 0.825) while throughput **fell on every prompt**. The
+ratio rises because you stopped drafting the low-probability tail, not because the drafter
+improved. The metric that tracks throughput is **mean accepted length**, which fell
+**4.84 -> 4.15**.
+
+## CUDA graphs do NOT transfer from TP4
+
+`cudagraph_mode: FULL_AND_PIECEWISE` is a clear win on the 4-node fleet (best aggregate
+503 -> 530 tok/s, prose +17%). On TP2, with only that flag changed, it is **flat**:
+
+| C | eager | FULL_AND_PIECEWISE | delta |
+|---|---|---|---|
+| 1 | 44.75 | 46.58 | +4.1% |
+| 2 | 68.18 | 65.05 | −4.6% |
+| 4 | 64.83 | 65.53 | +1.1% |
+| 6 | 84.82 | 83.34 | −1.7% |
+
+Mean ≈ −0.3%. Single stream is mixed (tooluse +13.5%, prose +10.2%, sql −15.9%).
+
+**Plausible mechanism:** at TP4 each rank holds ~1/4 of the model, so per-step kernel-launch
+overhead is a larger share of a shorter step and removing it pays. At TP2 each rank holds
+~1/2, the step is longer and more weight-read-bound, and the same overhead is proportionally
+smaller. **TP2 keeps `--enforce-eager`.**

--- a/launch-glm53-vllm-tp2-dflash2.sh
+++ b/launch-glm53-vllm-tp2-dflash2.sh
@@ -92,7 +92,7 @@ docker run --gpus all -d \
     --tensor-parallel-size 2 \
     --gpu-memory-utilization 0.85 \
     --max-model-len 262144 \
-    --max-num-seqs 6 --block-size 2304 --moe-backend marlin --speculative-config '{"method":"dflash","model":"/models/dflash2-draft","num_speculative_tokens":7}' --kv-cache-dtype fp8_e4m3 --kv-cache-memory 3221225472 \
+    --max-num-seqs 6 --block-size 2304 --moe-backend marlin --speculative-config '{"method":"dflash","model":"/models/dflash2-draft","num_speculative_tokens":7}' --kv-cache-dtype fp8_e4m3 --kv-cache-memory 6442450944 \
     --enforce-eager --max-num-batched-tokens 8192 \
     --tool-call-parser glm47 --enable-auto-tool-choice \
     --reasoning-parser glm45 --default-chat-template-kwargs '{"enable_thinking":false}' --chat-template /models/glm-5.3-flash-nvfp4/chat_template_mm.jinja \

--- a/probes/bench_robust.py
+++ b/probes/bench_robust.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""bench_robust.py — statistically robust sweep for GLM-5.3-Flash on 2x DGX Spark.
+
+Upgrades over bench_c1c6.py:
+  - N waves per level (default 4) + full per-request capture
+  - Per-level mean +/- stdev and 95% CI (t-distribution via sample stats)
+  - TTFT measured per request via streaming (interchunk SSE) + TPOT + decode tok/s
+  - P50/P90/max wall per level
+  - Mixed prompt set: code, reasoning, prose (acceptance varies by type)
+  - Interleaved level order to decorrelate thermal/scheduler drift
+  - Spec-decode acceptance delta per level from /metrics (as before)
+
+Usage: python3 bench_robust.py [--url http://localhost:8000] [--waves 4]
+       [--max-tokens 400] [--levels 1,2,3,4,5,6] [--tag NAME]
+"""
+import argparse, json, math, random, statistics, threading, time, urllib.request
+
+URL = "http://localhost:8000"
+
+PROMPTS = [
+    # code (high acceptance expected)
+    ("code", "Write a Python function that parses an nginx access log line into a dict, with a regex, and explain each group."),
+    ("code", "Implement a rate limiter class in Python using the token bucket algorithm, then show example usage."),
+    ("code", "Implement binary search in Python, then walk through the trace on [2,5,8,12,17,23] searching for 17."),
+    ("code", "Write a SQL query for the top 5 customers by 90-day revenue, then rewrite it as a window function version."),
+    # reasoning
+    ("reason", "A warehouse ships 340 orders/day growing 6% weekly. Model 8 weeks of volume in a Python list comprehension and explain."),
+    ("reason", "Explain the difference between TCP slow start and congestion avoidance, then pseudocode both."),
+    ("reason", "Design a URL shortener: data model, hash strategy, collision handling, and read/write scaling. Be concrete."),
+    # prose (low acceptance expected)
+    ("prose", "Write a short essay on why coastal cities flood more often than inland ones, and what that means for insurance markets."),
+    ("prose", "Draft a polite but firm email declining a vendor proposal while leaving the door open for next year."),
+    ("prose", "Explain quantum entanglement to a curious 12-year-old using two everyday analogies."),
+]
+
+def http_post_stream(url, payload, timeout=900):
+    """POST with stream=True; returns (ttft_s, total_s, completion_tokens, content)."""
+    payload = dict(payload, stream=True)
+    req = urllib.request.Request(url + "/v1/chat/completions",
+        data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"})
+    t0 = time.time(); ttft = None; buf = []; usage = None
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data: "):
+                continue
+            body = line[6:]
+            if body == "[DONE]":
+                break
+            try:
+                ev = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            if ev.get("usage"):
+                usage = ev["usage"]
+            try:
+                delta = ev["choices"][0]["delta"].get("content") or ""
+            except (KeyError, IndexError, TypeError):
+                delta = ""
+            if delta:
+                if ttft is None:
+                    ttft = time.time() - t0
+                buf.append(delta)
+    total = time.time() - t0
+    ct = usage["completion_tokens"] if usage else max(1, round(sum(len(b) for b in buf)) // 4)
+    return ttft, total, ct, "".join(buf)
+
+def metrics_cum(url):
+    try:
+        txt = urllib.request.urlopen(url + "/metrics", timeout=10).read().decode()
+        drafted = accepted = None
+        for line in txt.splitlines():
+            if line.startswith("vllm:spec_decode_num_draft_tokens_total{"):
+                drafted = float(line.split()[-1])
+            elif line.startswith("vllm:spec_decode_num_accepted_tokens_total{"):
+                accepted = float(line.split()[-1])
+        return drafted, accepted
+    except Exception:
+        return None, None
+
+def ci95(vals):
+    if len(vals) < 2:
+        return 0.0
+    return statistics.stdev(vals) * 1.96 / math.sqrt(len(vals))
+
+def run_wave(url, c, max_tokens):
+    out = [None] * c
+    def one(i):
+        kind, text = PROMPTS[(i * 3 + c * 2 + random.randint(0, 9)) % len(PROMPTS)]
+        salt = f"[{random.randint(1, 10**12)}] "
+        payload = {"model": "glm-5.3-flash",
+                   "messages": [{"role": "user", "content": salt + text}],
+                   "max_tokens": max_tokens, "temperature": 1.0, "top_p": 0.95}
+        t0 = time.time()
+        try:
+            ttft, total, ct, content = http_post_stream(url, payload)
+            out[i] = {"ok": True, "kind": kind, "wall": total - t0 + t0 - t0 + total - (total - t0) if False else total,
+                      "ttft": ttft or (total), "ct": ct,
+                      "tps": ct / max(total, 1e-9), "len_ok": ct >= max_tokens * 0.9}
+        except Exception as e:
+            out[i] = {"ok": False, "err": str(e)[:80], "wall": time.time() - t0}
+    ts = [threading.Thread(target=one, args=(i,)) for i in range(c)]
+    t0 = time.time()
+    [t.start() for t in ts]; [t.join() for t in ts]
+    return out, time.time() - t0
+
+def summarize(level_rows):
+    walls = [r["wall"] for r in level_rows]
+    ttfts = [r["ttft"] for r in level_rows]
+    tpss  = [r["tps"] for r in level_rows]
+    def pct(v, p):
+        s = sorted(v); k = max(0, min(len(s) - 1, round(p / 100 * (len(s) - 1))))
+        return s[k]
+    return {
+        "n": len(walls),
+        "wall_mean": round(statistics.mean(walls), 2),
+        "wall_stdev": round(statistics.stdev(walls), 2) if len(walls) > 1 else 0.0,
+        "wall_p50": round(pct(walls, 50), 2),
+        "wall_p90": round(pct(walls, 90), 2),
+        "ttft_mean": round(statistics.mean(ttfts), 2),
+        "ttft_p90": round(pct(ttfts, 90), 2),
+        "tps_mean": round(statistics.mean(tpss), 2),
+        "tps_ci95": round(ci95(tpss), 2),
+    }
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default=URL)
+    ap.add_argument("--waves", type=int, default=4)
+    ap.add_argument("--max-tokens", type=int, default=400)
+    ap.add_argument("--levels", default="1,2,3,4,5,6")
+    ap.add_argument("--tag", default="run")
+    a = ap.parse_args()
+
+    levels = [int(x) for x in a.levels.split(",")]
+    # interleave: pass1 runs levels ascending, pass2 descending, etc.
+    order = []
+    for w in range(a.waves):
+        chunk = levels if w % 2 == 0 else list(reversed(levels))
+        order.extend((w, c) for c in chunk)
+
+    # warmup
+    http_post_stream(a.url, {"model": "glm-5.3-flash",
+        "messages": [{"role": "user", "content": "Explain hash maps in 200 words."}],
+        "max_tokens": 300, "temperature": 1.0, "top_p": 0.95})
+
+    per_level = {c: [] for c in levels}
+    d_prev, a_prev = metrics_cum(a.url)
+    agg_by_wave = {}
+
+    for w, c in order:
+        out, wall = run_wave(a.url, c, a.max_tokens)
+        ok = [r for r in out if r["ok"]]
+        d_now, a_now = metrics_cum(a.url)
+        acc = (a_now - a_prev) / (d_now - d_prev) if (d_now and d_prev and a_now and a_prev and d_now > d_prev) else None
+        d_prev, a_prev = d_now, a_now
+        toks = sum(r["ct"] for r in ok)
+        agg = toks / wall if wall else 0
+        agg_by_wave.setdefault(c, []).append(agg)
+        per_level[c].extend(ok)
+        accs = f"{acc:.3f}" if acc else "n/a"
+        print(f"wave{w} C{c}: {len(ok)}/{c} ok  agg={agg:6.1f} tok/s  wall={wall:6.1f}s  accept={accs}", flush=True)
+
+    print("\n=== SUMMARY (per-request stats, all waves pooled) ===")
+    print(f"{'C':>2} {'n':>3} {'wall_mean':>9} {'wall_sd':>8} {'wall_p50':>8} {'wall_p90':>8} "
+          f"{'ttft_mean':>9} {'ttft_p90':>8} {'tps_mean':>8} {'tps_ci95':>8}")
+    final = {}
+    for c in levels:
+        s = summarize(per_level[c])
+        final[c] = s
+        print(f"{c:>2} {s['n']:>3} {s['wall_mean']:>9.2f} {s['wall_stdev']:>8.2f} {s['wall_p50']:>8.2f} {s['wall_p90']:>8.2f} "
+              f"{s['ttft_mean']:>9.2f} {s['ttft_p90']:>8.2f} {s['tps_mean']:>8.2f} {s['tps_ci95']:>8.2f}")
+
+    print("\n=== per-prompt-type decode tok/s (mean) ===")
+    for kind in ("code", "reason", "prose"):
+        v = [r["tps"] for c in levels for r in per_level[c] if r["kind"] == kind]
+        if v:
+            print(f"{kind:>7}: {statistics.mean(v):6.2f} tok/s  (n={len(v)})")
+
+    peak_c = max(final, key=lambda c: statistics.mean([x for x in agg_by_wave[c]]))
+    print(f"\npeak aggregate by mean wave agg: C{peak_c} = "
+          f"{statistics.mean(agg_by_wave[peak_c]):.1f} tok/s")
+
+    with open(f"/tmp/bench_robust_{a.tag}.json", "w") as f:
+        json.dump({"tag": a.tag, "waves": a.waves, "max_tokens": a.max_tokens,
+                   "summary": final, "wave_agg": agg_by_wave}, f, indent=1)
+    print(f"saved -> /tmp/bench_robust_{a.tag}.json")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lands the generalisable parts of #12 (@tmooch), reproduced on the reference pair.

**Why not merge #12 directly:** it carries a site-specific fabric retarget — `RANK_ORDER=(1 0)`, `zeus@192.168.100.11`, `192.168.100.0/24`, a different checkpoint name — which their PR description flags honestly. Merging it wholesale would point this repo's launchers at their hosts. So this takes the findings and the harness, and leaves the retarget out.

## Reproduced

Each arm under its own `VLLM_CACHE_ROOT` so vLLM #53366 can't cross-contaminate the k arms.

**k=5 vs k=7 inverts at C4** — their C6 claim holds:

| C | k=7 | k=5 | delta |
|---|---|---|---|
| 1 | 44.75 | 42.18 | −5.7% |
| 2 | 68.18 | 64.12 | −6.0% |
| **4** | 64.83 | **84.20** | **+29.9%** |
| **6** | 84.82 | **100.33** | **+18.3%** |

Single stream goes the other way — k=5 slower on all 8 prompts, count-to-100 −17.3%. So **k is a workload choice, not a default.** Default stays 7; deep concurrency wants a schedule with the crossover at C4.

## The measurement trap worth documenting

Under k=5 the acceptance **ratio rose on every prompt** (0.940→0.977, 0.664→0.748, 0.736→0.825) while throughput **fell on every prompt**. The ratio rises because you stopped drafting the low-probability tail. **Mean accepted length** is what tracks throughput: **4.84 → 4.15**. Anyone tuning toward a higher ratio will make this slower.

## CUDA graphs do not transfer from TP4

Same flag that took TP4 from 503 → 530 aggregate is **flat on TP2** (mean −0.3%: +4.1 / −4.6 / +1.1 / −1.7). TP2 keeps `--enforce-eager`. Plausibly because each TP2 rank holds ~1/2 the model, so the step is longer and launch overhead is proportionally smaller.

## Contents

- KV 3 → 6 GiB in the dflash2 launcher (6 preemptions → 0 under load)
- `probes/bench_robust.py` from #12 — interleaved waves, per-request P50/P90
- `docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)