### PR TITLE
Cleanup step 1: CURRENT.md; README says what the launcher does (KV pinned 6 GiB, RedHat weights path); doc pins corrected

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- This repo keeps ONE current recipe, written down in CURRENT.md. A PR is checked against that file, not against the whole tree. -->
+
+**Which line of CURRENT.md does this change?**
+(quote it, or write "none: docs/tooling only")
+
+**What is the new value, and what number proves it?**
+(flag, before -> after, the prompt type and temperature of the measurement, and where the log or JSON lives)
+
+**Tested on**
+(hardware, image tag, weights dir, date)
+
+**Checklist**
+- [ ] I rebased on current `main` (stale PRs merge old configs over the current recipe)
+- [ ] `CURRENT.md` updated in this PR if a launcher or a serving flag changed, and `bash tools/check-current.sh --write` was run
+- [ ] Speed numbers are from real prompts (prose, code, ...); any counting-prompt number is labeled as the draft-acceptance ceiling; prefill is cold

--- a/.github/workflows/current-check.yml
+++ b/.github/workflows/current-check.yml
@@ -1,0 +1,25 @@
+name: CURRENT.md guard
+# Fails a PR that changes a launcher without changing CURRENT.md, or whose CURRENT.md
+# launcher hashes do not match the launchers in the tree. Keeps the golden recipe honest:
+# any config change has to be written down in the one file agents read first.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+      - name: launchers changed => CURRENT.md must change too (PRs only)
+        if: github.event_name == 'pull_request'
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          changed=$(git diff --name-only "$base" HEAD)
+          if echo "$changed" | grep -qE '^(launchers/|launch-[^/]*\.sh$|[^/]*launch[^/]*\.sh$)'; then
+            echo "$changed" | grep -q '^CURRENT.md$' || { echo "::error::a launcher changed but CURRENT.md did not. Update the golden record in the same PR."; exit 1; }
+          fi
+      - name: CURRENT.md hashes match the launchers
+        run: bash tools/check-current.sh

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -1,0 +1,178 @@
+# CURRENT recipe
+
+The one configuration this repo ships today. If anything else in the repo disagrees with
+this file, this file wins.
+
+Last verified: 2026-09-02.
+
+---
+
+## Topology
+
+GLM-5.3-Flash NVFP4 + DFlash2, **tensor-parallel 2 across two DGX Spark (GB10/SM121) nodes**,
+**262,144-token context**.
+
+| rank | host | IP | role |
+|---|---|---|---|
+| **1** | Spark4 | `192.168.192.4` | worker (`--headless`) — **launch FIRST** |
+| **0** | Reddie | `192.168.192.2` | head — serves the OpenAI API on **:8000** |
+
+Rendezvous: master addr `192.168.192.2`, master port `29521`, `--nnodes 2`,
+`--distributed-executor-backend mp`.
+
+**1M-context TP2 variants starved the KV pool and crashed the fleet three times on
+2026-09-01. 262K is the current context.** Do not raise `--max-model-len` on TP2.
+
+## The one launcher
+
+```bash
+sync; echo 3 | sudo tee /proc/sys/vm/drop_caches      # BOTH nodes, every launch
+./launch-glm53-vllm-tp2-dflash2.sh 1    # Spark4, rank 1, worker — FIRST
+sleep 25
+./launch-glm53-vllm-tp2-dflash2.sh 0    # Reddie, rank 0, head — serves :8000
+```
+
+[`launch-glm53-vllm-tp2-dflash2.sh`](launch-glm53-vllm-tp2-dflash2.sh) is the only launcher
+for this recipe. The drop-caches step is not optional on these unified-memory nodes.
+
+Readiness takes ~15 minutes (shard load dominates). Poll `/health`, never `/v1/models` —
+the latter returns 200 from config alone with a dead engine behind it.
+
+## Image
+
+```
+ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2
+```
+
+Public, anonymous pull, on **both** nodes. Also required on both nodes before launch:
+`cp docker/sparse_attn_indexer_kpool_sm121.py ~/patches/sparse_attn_indexer_kpool.py`
+(the SM121 top-k fix the launcher bind-mounts over the image's copy).
+
+## Weights
+
+```
+/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat
+```
+
+This is the path the launcher checks (`MODEL_HOST_PATH`), on both nodes.
+[RedHatAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/RedHatAI/GLM-5.3-Flash-NVFP4),
+compressed-tensors.
+
+**ModelOpt and abliterated NVFP4 quants corrupt tokens on this stack; the launcher refuses
+them.** The guard reads `quantization_config.quant_method` from `config.json` and exits 5 on
+`modelopt` unless `ALLOW_MODELOPT=1` (vLLM
+[#54150](https://github.com/vllm-project/vllm/issues/54150)).
+
+The drafter, also on both nodes: `/var/tmp/models/GLM-5.3-Flash-DFlash2` (2.2 GB,
+[incoai/GLM-5.3-Flash-DFlash2](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2)).
+
+## Flags that define the recipe
+
+| flag | value | why |
+|---|---|---|
+| `--tensor-parallel-size` | `2` | two Sparks |
+| `--max-model-len` | `262144` | 1M starved the pool and crashed 3× on 2026-09-01 |
+| `--speculative-config` | `{"method":"dflash","model":"/models/dflash2-draft","num_speculative_tokens":7}` | DFlash2, **k=7** |
+| `--kv-cache-dtype` | `fp8_e4m3` | |
+| `--kv-cache-memory` | `6442450944` (**6 GiB, pinned**) | see below |
+| `--enforce-eager` | on | see below |
+| `--gpu-memory-utilization` | `0.85` | 0.78–0.80 starve KV; 0.87 is not reachable on every node |
+| `--block-size` | `2304` | DeepGEMM arch-12 fp8 paged-MQA needs 64-entry pool pages |
+| `--moe-backend` | `marlin` | |
+| `--max-num-seqs` | `6` | |
+| `--max-num-batched-tokens` | `8192` | |
+| `--chat-template` | `chat_template_mm.jinja` (from the weights dir) | vision; image requests 500 without it |
+| `--served-model-name` | `glm-5.3-flash` | |
+| tool/reasoning | `--tool-call-parser glm47 --enable-auto-tool-choice --reasoning-parser glm45 --default-chat-template-kwargs '{"enable_thinking":false}'` | |
+
+### KV **is** pinned at 6 GiB
+
+This reverses earlier README guidance ("let the profiler size the pool, do not pin
+`--kv-cache-memory`"). The shipped launcher pins **6442450944 bytes**. Rationale and
+measurement: [`docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md`](docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md),
+section "KV 3 -> 6 GiB: unconditional" — 6 preemptions under load at 3 GiB, **0 at 6 GiB**,
+with the pool going **310,292 -> 678,661 tokens**. Preemption under load costs more than any
+tok/s figure, and the memory is available. Adopted as the default in
+[#16](https://github.com/tonyd2wild/GLM-5.3-Flash-NVFP4-DFlash2-2x-DGX-Spark/pull/16).
+
+Measured KV pool at the shipped pin: **678,661 tokens**.
+
+### `--enforce-eager` stays on for TP2
+
+CUDA graphs are the **TP4 sibling repo's lane**, not this one. Same doc, section "CUDA graphs
+do NOT transfer from TP4": `cudagraph_mode: FULL_AND_PIECEWISE` is a clear win at TP4
+(503 -> 530 tok/s aggregate) and **flat** at TP2 — C1 +4.1%, C2 −4.6%, C4 +1.1%, C6 −1.7%,
+mean ≈ −0.3%. TP2 keeps `--enforce-eager`.
+
+## Expected numbers
+
+All from [`docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md`](docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md),
+section "Speculative depth: k=7 below C4, k=5 above it" — measured 2026-09-02, RedHatAI
+compressed-tensors checkpoint, DFlash2, temperature 0, 8-prompt set, median of 3, each arm
+under its own `VLLM_CACHE_ROOT`.
+
+Shipped config (k=7), aggregate by concurrency:
+
+| C | tok/s |
+|---|---|
+| 1 | 44.75 |
+| 2 | 68.18 |
+| 4 | 64.83 |
+| 6 | 84.82 |
+
+Shipped config (k=7), single stream by prompt:
+
+| prompt | tok/s |
+|---|---|
+| count-to-100 | 67.12 |
+| code | 47.33 |
+| tooluse | 48.72 |
+| sql | 41.19 |
+| json | 46.73 |
+| math | 41.26 |
+
+`num_speculative_tokens` is a workload choice, not a default: the same section measures k=5
+beating k=7 by +29.9% at C4 and +18.3% at C6, while losing on every single-stream prompt.
+Deep-concurrency serving should set k=5, or use the schedule with the crossover at C4:
+`"num_speculative_tokens_per_batch_size": [[1,3,7],[4,512,5]]`. **The default stays k=7.**
+
+## How we quote numbers
+
+- **Decode** is quoted from **real prompts** — prose and code — because acceptance, and
+  therefore throughput, is workload-bound. A single decode number without the prompt mix is
+  not comparable to anything.
+- **The counting prompt** (count-to-100 and friends) is quoted only as a **labeled
+  draft-acceptance ceiling**. It is the most predictable text the drafter will ever see; it is
+  not a decode figure and must never be presented as the headline.
+- **Prefill** is quoted **cold only**. First inference JIT-compiles kernels, so a warm prefill
+  number measures the cache, not the stack.
+
+## Four Sparks?
+
+Use the sibling repo:
+**[GLM-5.3-Flash-NVFP4-1M-KV-4x-DGX-Spark](https://github.com/tonyd2wild/GLM-5.3-Flash-NVFP4-1M-KV-4x-DGX-Spark)**
+— TP4, the model-native 1M context, and the lane where CUDA graphs pay.
+
+## Do not use
+
+Superseded. Kept for history and for links from open issues and PRs; **moving to `archive/`
+in the next cleanup commit**. None of these describes the current recipe:
+
+| path | superseded by |
+|---|---|
+| `launch-glm53-vllm-tp2.sh` | `launch-glm53-vllm-tp2-dflash2.sh` (no-drafter v8 lane) |
+| `launch-glm53-vllm-tp4.sh` | the TP4 sibling repo |
+| `cache_flusher.sh` | the `drop_caches` line above |
+| `overlay-dflash2/` | `docker/dflash2-overlay/` |
+| `docs/DEPLOY-REPORT.md` | this file + `docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md` |
+| `docs/BENCH-C1-C6-DFLASH2.md` | `docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md` |
+| `docs/GB10-KV-MEMORY-LADDER.md` | the 6 GiB pin above |
+| `docs/KV-HUNT-672K-TP2-RECORD.md` | the 6 GiB pin above |
+| `docs/NVFP4-KV-BUILD-SPEC.md` | fp8 KV is the shipped lane; NVFP4 KV is unresolved |
+| `docs/kv_hunt_log.md` | the 6 GiB pin above |
+| `probes/bench_glm53.py` | `probes/bench_robust.py` |
+
+Still current: `docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md`,
+`docs/SM121-CRASH-FORENSICS-2026-08-27.md`, `docs/DFLASH2-SPECULATIVE-DECODING.md`,
+`docs/OPEN-PROBLEMS.md`, `docs/issue-*.md`, `docker/`, `probes/bench_c1c6.py`,
+`probes/bench_robust.py`, and the probe kit.

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -131,6 +131,22 @@ Shipped config (k=7), single stream by prompt:
 | json | 46.73 |
 | math | 41.26 |
 
+Real prompts, this exact recipe run verbatim on Reddie + Spark4 on 2026-09-01, isolated, temperature 0
+(40-prompt battery, 8 categories, three runs; source: the EXL3 comparison repo,
+https://github.com/tonyd2wild/GLM-5.3-Flash-EXL3-on-2x-NVIDIA-DGX-Spark/blob/main/results/summary.md):
+
+| | tok/s or s |
+|---|---|
+| prose decode, single stream | 18.8 (range 18.8 to 19.8) |
+| code decode, single stream | 52.2 (range 48.3 to 57.7) |
+| mixed load, four real prompts in flight | 31.4 tok/s aggregate, first token 1.97 s |
+| first token, fresh 1.6K prompt, c1 / c6 | 1.29 s / 4.53 s |
+| cold prefill, fresh 211K prompt | 2,763 tok/s |
+| counting prompt, single stream (ceiling only) | 64.0 |
+
+The 46.9 tok/s in the README (2026-08-28, `probes/bench_c1c6.py`, code prompt) and the 47.33 above
+(2026-09-02 doc) are the same measurement on different days and harnesses; quote either with its date.
+
 `num_speculative_tokens` is a workload choice, not a default: the same section measures k=5
 beating k=7 by +29.9% at C4 and +18.3% at C6, while losing on every single-stream prompt.
 Deep-concurrency serving should set k=5, or use the schedule with the crossover at C4:
@@ -176,3 +192,8 @@ Still current: `docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md`,
 `docs/SM121-CRASH-FORENSICS-2026-08-27.md`, `docs/DFLASH2-SPECULATIVE-DECODING.md`,
 `docs/OPEN-PROBLEMS.md`, `docs/issue-*.md`, `docker/`, `probes/bench_c1c6.py`,
 `probes/bench_robust.py`, and the probe kit.
+
+<!-- launcher hashes, maintained by tools/check-current.sh --write -->
+sha256 5b3713873a92e6b86ab73f4a34942fc4429ee728d9d36add703fe7508ff43895  launch-glm53-vllm-tp2-dflash2.sh
+sha256 9e0ca234ece25786c9109fe9b3121e0ba024b32a741fb9cd7feb6861a6f76df6  launch-glm53-vllm-tp2.sh
+sha256 5d1fedd3b586819668d8f6f6759d2483fbd785aadad2a25139cbf90639c27929  launch-glm53-vllm-tp4.sh

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # GLM-5.3-Flash NVFP4 + DFlash2 on 2x NVIDIA DGX Spark
 
-OpenAI-compatible vLLM serving of [zai-org/GLM-5.3-Flash](https://huggingface.co/zai-org/GLM-5.3-Flash)
-(320B total / 18B active MoE) across two DGX Spark (GB10, SM121) nodes at tensor-parallel 2,
-using the [RedHatAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/RedHatAI/GLM-5.3-Flash-NVFP4)
-compressed-tensors quant (the corruption-free **default**, see below), **fp8 KV cache**, and the [`incoai/GLM-5.3-Flash-DFlash2`](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2)
-speculative drafter. 262,144-token context. Deployed the same day the model dropped.
+[zai-org/GLM-5.3-Flash](https://huggingface.co/zai-org/GLM-5.3-Flash) (320B total / 18B active MoE) served by vLLM at **tensor-parallel 2 across two DGX Spark** (GB10/SM121), **262,144-token context**, fp8 KV, DFlash2 speculative drafter.
+
+**Current recipe: [CURRENT.md](CURRENT.md).** Read that first — it is the one configuration this repo ships, and it wins over anything below that disagrees.
+
+One launcher: [`launch-glm53-vllm-tp2-dflash2.sh`](launch-glm53-vllm-tp2-dflash2.sh) — **worker Spark4 (rank 1) FIRST, then head Reddie (rank 0)**, which serves :8000.
+
+Weights: [RedHatAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/RedHatAI/GLM-5.3-Flash-NVFP4) (compressed-tensors) at `/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat` — ModelOpt and abliterated NVFP4 quants corrupt tokens on this stack and the launcher refuses them.
+
+Everything else here is reference: the bring-up log, the day-0 bug receipts, the benchmark history, and the open problems.
 
 ---
 
@@ -54,17 +58,14 @@ docker pull ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v8            # base, fp8 
 ```
 
 They contain **only vLLM + our patches** — no model weights (those bind-mount at runtime).
-The launchers reference the local `radixark/…` tag names, so retag once:
-
-```bash
-docker tag ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v8 ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v8
-docker tag ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2 ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2
-```
+No retag step: the launchers reference these `ghcr.io/tonyd2wild/…` tags directly. (Only the
+`docker/` build chain uses local `radixark/…` stage tags, and those never leave the build.)
 
 **2. Fetch the weights** to the same path on both nodes (or NFS-export from the head):
 [RedHatAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/RedHatAI/GLM-5.3-Flash-NVFP4) (default) →
-`/var/tmp/glm-5.3-flash-nvfp4`. For DFlash2, also fetch the drafter (2.2 GB) →
-`/var/tmp/models/GLM-5.3-Flash-DFlash2`.
+`/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat` — this is the path the launcher checks
+(`MODEL_HOST_PATH`); override with `MODEL_HOST_PATH=…` if you keep weights elsewhere. For
+DFlash2, also fetch the drafter (2.2 GB) → `/var/tmp/models/GLM-5.3-Flash-DFlash2`.
 
 **3. Install the SM121 top-k fix** on **both** nodes. Both published images still contain a
 decode-time top-k kernel that hard-kills the engine on any decode past ~24K context on GB10
@@ -128,10 +129,11 @@ docker save ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v8 | ssh <worker> docker l
 The chain is mostly linear (v1→v3→v4→…→v9); **v2 is an optional NaN-debug branch off v1** that nothing else builds on. For DFlash2, build
 [`overlay-dflash2/`](overlay-dflash2/) on top of v8 afterwards.
 
-> **Known issue:** on `main` the `FROM` lines of v2–v6 still reference the original ad-hoc tag
-> names (`sm121-nope-mla`, `sm121-fi618`, `sm121-fi618-nccl`, `sm121-final`) rather than
-> `sm121-v1…v5`, so the loop above only works after [#5](../../pull/5) (thanks @ozskywalker)
-> lands. Until then, tag each stage with the name the next Dockerfile expects.
+> **Resolved.** The `FROM` lines of v2–v6 once referenced the original ad-hoc tag names
+> (`sm121-nope-mla`, `sm121-fi618`, `sm121-fi618-nccl`, `sm121-final`) rather than
+> `sm121-v1…v5`, so the loop above did not work. [#5](../../pull/5) (thanks @ozskywalker)
+> normalized the chain to v-numbered tags and added `docker/build.sh`; no manual retagging
+> between stages is needed.
 
 Published image digests, so you can tell whether a local build differs:
 `sm121-v8` → `sha256:d77d375c742fc54f436dec5108b440f58f021bc6600052bf0e8fe5840357e78f` ·
@@ -179,9 +181,23 @@ lives in the high-acceptance zone. Detail and how to read these:
 
 ### KV pool ceiling on TP2 (2026-08-28)
 
+> **Superseded 2026-09-02 — the shipped launcher now pins `--kv-cache-memory 6442450944`
+> (6 GiB).** The guidance below ("let the profiler size the pool, never pin") was written
+> before we measured what the profiler-sized pool costs under load: at the 3 GiB pin
+> @tmooch measured 6 preemptions under load and 0 at 6 GiB, with the pool going
+> **310,292 → 678,661 tokens**. Preemption under load costs more than any tok/s figure and
+> the memory is available, so 6 GiB was adopted as the default in
+> [#16](../../pull/16). Measurement and reasoning:
+> [docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md](docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md).
+> The sharp edge below is still real — a pin removes the activation reservation — which is
+> why the shipped pin is a *measured* one, validated under load, not a guess. Do not raise
+> it without repeating that measurement.
+
+The original 2026-08-28 finding, kept because the mechanism still matters:
+
 **Let vLLM's profiler size the pool. Do not pin `--kv-cache-memory`.**
 
-That is the entire lesson, and it cost us a night of boots to learn. When you pass
+That was the lesson at the time, and it cost us a night of boots to learn. When you pass
 `--kv-cache-memory`, vLLM still runs the profile pass but **never subtracts the measured
 activation peak** (`gpu_worker.py:475-495`) — it hands you exactly the number you asked
 for and `--gpu-memory-utilization` becomes dead. Allocation succeeds, warmup succeeds, a
@@ -233,9 +249,18 @@ point. It does not recover on its own.
 - **`enable_thinking: false` is also the faster setting** (+8 % acceptance) — reasoning traces
   are higher-entropy and draft worse. Caveat: with thinking off GLM emits untagged
   reasoning-prose into `content`, which some agent harnesses mis-parse; see the deploy report.
-- **K=7 is optimal, don't sweep it.** Conditional per-position acceptance is nearly flat
-  (0.93/0.89/0.84/0.81/0.79/0.59/0.94), so the last position still earns; the drafter's
-  `block_size: 8` caps K at 7 anyway. A lower K gives a prettier *ratio* and worse throughput.
+- **K=7 is the default, but it is a workload choice — it was swept.** Conditional per-position
+  acceptance is nearly flat (0.93/0.89/0.84/0.81/0.79/0.59/0.94), so the last position still
+  earns; the drafter's `block_size: 8` caps K at 7 anyway, and a lower K gives a prettier
+  *ratio* and worse throughput on a single stream. **But the sweep on 2026-09-02
+  ([docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md](docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md),
+  "Speculative depth: k=7 below C4, k=5 above it") found it inverts under concurrency** —
+  k=5 beats k=7 by +29.9% at C4 and +18.3% at C6, while losing on every single-stream prompt.
+  That doc's result, quoted: "`num_speculative_tokens` is a **workload choice, not a
+  default.** It inverts at C4… **The default stays k=7** (single-user and low-concurrency is
+  the common case, and it is what the README's headline figures use). Serving deep
+  concurrency should set k=5, or better, use a schedule with the crossover at C4:
+  `"num_speculative_tokens_per_batch_size": [[1,3,7],[4,512,5]]`"
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ harness is [`probes/bench_c1c6.py`](probes/bench_c1c6.py), run as:
 |---|---|
 | Single-stream decode, code prompt, warm | **46.9 tok/s** at 74.1 % draft acceptance |
 | Single-stream decode, structured output | **54–61 tok/s** (temp 0, 3 runs) |
-| KV pool | **581,040 tokens** @ 262K context, profiler-sized (see the ceiling section) |
+| KV pool | **678,661 tokens** @ 262K context at the shipped 6 GiB pin (PR #16; 581,040 under profiler sizing before it, see the ceiling section) |
 | Context | 262,144 |
 | KV cost of the drafter | **zero** — it slot-shares the MLA tensors |
 | Boot | ~15 min (shard load dominates) |

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,2 +1,14 @@
 #!/bin/sh
-for i in $(seq 1 9); do docker build -f "Dockerfile.glm53-sm121-v$i" -t "radixark/vllm-glm53-flash:sm121-v$i" . || break; done
+# Build the sm121 image chain v1 -> v9. Each stage FROMs the previous one, so a failure
+# at stage N makes every later stage meaningless: stop there and say which one failed.
+#
+# Tag names: this script tags stages `radixark/vllm-glm53-flash:sm121-vN` (the local build
+# chain the Dockerfiles' FROM lines expect). The images the README tells you to pull are
+# published under `ghcr.io/tonyd2wild/vllm-glm53-flash:` tags. Same content, different
+# namespace -- the radixark tags are build-local and never pushed.
+for i in $(seq 1 9); do
+  if ! docker build -f "Dockerfile.glm53-sm121-v$i" -t "radixark/vllm-glm53-flash:sm121-v$i" .; then
+    echo "build.sh: FAILED at stage v$i (Dockerfile.glm53-sm121-v$i); stages v$i-v9 not built" >&2
+    exit 1
+  fi
+done

--- a/docs/DFLASH2-SPECULATIVE-DECODING.md
+++ b/docs/DFLASH2-SPECULATIVE-DECODING.md
@@ -130,7 +130,10 @@ Healthy runtime signatures:
 - Concurrency is bounded by free-memory headroom, not the pool: at
   `--kv-cache-memory 4445787956` a 3-way 20K-token prefill drove MemAvailable to
   3.06 GB and Tony's `dgx-anti-oom` watchdog (threshold 3 GB) killed the engine.
-  Shipping pin is **3221225472** (310,292-token pool) for headroom under load.
+  Shipping pin is **6442450944** (678,661-token pool) for headroom under load.
+  Changed in [#16](../../pull/16): the previous pin was **3221225472** (310,292-token pool),
+  which measured 6 preemptions under load where 6 GiB measured 0. See
+  [TP2-SPEC-DEPTH-AND-KV-2026-09-02](TP2-SPEC-DEPTH-AND-KV-2026-09-02.md).
 
 
 ## NVFP4-KV lane (partial)

--- a/docs/OPEN-PROBLEMS.md
+++ b/docs/OPEN-PROBLEMS.md
@@ -122,6 +122,8 @@ recovers it or a reboot is required.
 
 ## 5. Pinning `--kv-cache-memory` silently removes the activation reservation
 
+> Superseded by the shipped launcher / [#16](../../pull/16): TP2 now pins 6442450944 (6 GiB), a measured pin validated under load — the sharp edge below is why it is measured rather than guessed. See [TP2-SPEC-DEPTH-AND-KV-2026-09-02](TP2-SPEC-DEPTH-AND-KV-2026-09-02.md).
+
 Not a bug so much as a very sharp edge, documented here because it cost us most of a night
 and the failure mode is deeply misleading.
 
@@ -162,6 +164,8 @@ pre-launch flush is untested.
 ---
 
 ## 7. Smaller open items
+
+> "CUDA graphs untested with DFlash2" below is superseded by the shipped launcher / [#16](../../pull/16): tested on TP2 2026-09-02 and flat (mean ≈ −0.3%), so TP2 keeps `--enforce-eager` — see [TP2-SPEC-DEPTH-AND-KV-2026-09-02](TP2-SPEC-DEPTH-AND-KV-2026-09-02.md).
 
 - **Vision is not speculated.** The drafter logs `does not support external multimodal
   embeddings … using text-only draft inputs`. Image requests work but get no speedup.

--- a/tools/check-current.sh
+++ b/tools/check-current.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# tools/check-current.sh: verify that every "sha256 <hex>  <path>" line in CURRENT.md matches the
+# file in the tree, and that every launcher listed under launchers/ (or the repo's named launcher)
+# has such a line. Run locally before a PR; CI runs it on every PR and push to main.
+#   Update the hashes after an intentional change:  bash tools/check-current.sh --write
+set -u
+cd "$(dirname "$0")/.."
+[ -f CURRENT.md ] || { echo "no CURRENT.md at the repo root"; exit 1; }
+sha() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -c1-64; else shasum -a 256 "$1" | cut -c1-64; fi; }
+launchers=$( { ls launchers/*.sh 2>/dev/null; ls launch-*.sh 2>/dev/null; } | sort -u)
+if [ "${1:-}" = "--write" ]; then
+  tmp=$(mktemp)
+  grep -vE '^sha256 [0-9a-f]{64}  ' CURRENT.md > "$tmp"
+  { cat "$tmp"; echo; echo "<!-- launcher hashes, maintained by tools/check-current.sh --write -->"; for f in $launchers; do echo "sha256 $(sha "$f")  $f"; done; } > CURRENT.md
+  rm -f "$tmp"; echo "CURRENT.md hashes written for: $launchers"; exit 0
+fi
+rc=0
+for f in $launchers; do
+  want=$(grep -E "^sha256 [0-9a-f]{64}  $f\$" CURRENT.md | awk '{print $2}' | head -1)
+  have=$(sha "$f")
+  if [ -z "$want" ]; then echo "MISSING: $f has no sha256 line in CURRENT.md"; rc=1
+  elif [ "$want" != "$have" ]; then echo "DRIFT: $f changed but CURRENT.md still lists $want"; rc=1
+  else echo "ok: $f"; fi
+done
+[ $rc -eq 0 ] && echo "CURRENT.md matches the launchers." || echo "Fix: edit CURRENT.md to describe the change, then: bash tools/check-current.sh --write"
+exit $rc


### PR DESCRIPTION
Step 1 of the repo cleanup (nothing archived or deleted yet; that is the next PR). Goal: one page that says exactly what runs, and docs that agree with the shipped launcher.

- `CURRENT.md`: the one TP2 launcher, rank order, image, weights (RedHatAI compressed-tensors; the launcher refuses ModelOpt builds), every flag, expected numbers from `docs/TP2-SPEC-DEPTH-AND-KV-2026-09-02.md` plus the real-prompt numbers measured on this exact recipe on 2026-09-01 (prose 18.8 / code 52.2 tok/s single stream, cold prefill 2,763 tok/s at 211K), and the reporting convention (decode from real prompts; counting only as a labeled ceiling; prefill cold).
- README: the sentence that told operators not to pin `--kv-cache-memory` (the shipped launcher pins 6 GiB since PR #16), the quickstart weights path (the launcher exits on the old one), the retag block that retagged images to their own names, the "known issue" PR #5 already fixed, the k=7 note (the 09-02 doc measured k=5 +29.9% at C4), the KV pool row (678,661 at the shipped pin; 581,040 was profiler-sized).
- `docs/DFLASH2-SPECULATIVE-DECODING.md` pin value; `docs/OPEN-PROBLEMS.md` items 5 and 7 marked superseded.
- `docker/build.sh`: a failed stage now prints which stage failed and exits non-zero instead of silently stopping the loop.
- `tools/check-current.sh` + GitHub Action + PR template: a PR that touches a launcher without updating `CURRENT.md`, or whose hashes drift, fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142pDPCMasdrPVASkqdsC5Y